### PR TITLE
Fix del entries printing

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -77,7 +77,7 @@ class App:
             A string containing a table of bibliography entries
         """
         table_data = []
-        for key, entry in entries.items():
+        for idx, (key, entry) in enumerate(entries.items()):
             authors = " and ".join(
                 str(person) for person in entry.persons.get("author", [])
             )
@@ -85,10 +85,10 @@ class App:
             journal = entry.fields.get("journal", entry.fields.get("publisher", "N/A"))
             year = entry.fields.get("year", "N/A")
 
-            table_data.append([key, authors, title, journal, year])
+            table_data.append([idx, key, authors, title, journal, year])
 
         return tabulate(
-            table_data, headers=["Citekey", "Author", "Title", "Journal", "Year"]
+            table_data, headers=["ID", "Citekey", "Author", "Title", "Journal", "Year"]
         )
 
     def find_entries_by_title(self, searched):

--- a/src/main.py
+++ b/src/main.py
@@ -110,19 +110,7 @@ def del_entries(io, app: App):
     valid_index_range = range(len(entries))
     indices_to_remove = set()
 
-    # pretty formatting here
-    # prolly simply call the listing function once done with the addition of indices
-    io.print(
-        f"\n{'ID':^3} | {'author':^10} | {'title':^10} | {'journal':^10} | {'year':^10}"
-    )
-    for idx, (_entry_key, entry) in enumerate(entries.items()):
-        fields = entry.fields
-        person = entry.persons
-        author = ",".join([str(x) for x in person["author"]])
-        io.print(
-            f"{idx:^3} | {author:^10} | {fields['title']:^10} "
-            + f"| {fields['journal']:^10} | {fields['year']:^10}"
-        )
+    io.print(app.tabulate_entries(entries))
 
     reply = (
         io.input(

--- a/src/tests/commands.robot
+++ b/src/tests/commands.robot
@@ -76,9 +76,6 @@ Delete All Clears BiblioGraphy
     Skip Output
     Skip Output
     Skip Output
-    Skip Output
-    Skip Output
-    Skip Output
     Output Should Contain    No entries found
 
 User Can Delete One Entry
@@ -94,9 +91,6 @@ User Can Delete One Entry
     Add Input    list
     Add Input    exit
     Run Application
-    Skip Output
-    Skip Output
-    Skip Output
     Skip Output
     Skip Output
     Skip Output


### PR DESCRIPTION
This fix utilises tabulate_entries to print when deleting entries. Added indexin to tabulate so that functionality doesn't change from previous version. Commits are quite descriptive.