### PR TITLE
Make readme CI Badge only care about main branch runs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # miniprojekti
 
-![CI Badge](https://github.com/sevonj/miniprojekti/workflows/CI/badge.svg)
+![CI Badge](https://github.com/sevonj/miniprojekti/workflows/CI/badge.svg?branch=main)
 [![codecov](https://codecov.io/gh/sevonj/miniprojekti/graph/badge.svg?token=YENFDFJKT2)](https://codecov.io/gh/sevonj/miniprojekti)
 
 


### PR DESCRIPTION
Currently it displays the status of the latest CI run on _any_ branch.