### PR TITLE
Generate automatic citekeys

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -109,11 +109,10 @@ class App:
         """
 
         # Get first author's last name
-        author = (
-            entry.persons.get("author")[0].last_names[0]
-            if entry.persons.get("author")
-            else "N/A"
-        )
+        author = "N/A"
+        authors = entry.persons.get("author")
+        if authors and len(authors) > 0 and len(authors[0].last_names) > 0:
+            author = authors[0].last_names[0]
 
         # Get year
         year = entry.fields.get("year", "N/A")

--- a/src/app.py
+++ b/src/app.py
@@ -5,7 +5,6 @@ This module contains the service which the UI code can call.
 It should be kept UI-independent; No UI code here.
 
 """
-from uuid import uuid4
 import string
 import urllib.request
 from urllib.error import HTTPError

--- a/src/app.py
+++ b/src/app.py
@@ -6,6 +6,7 @@ It should be kept UI-independent; No UI code here.
 
 """
 from uuid import uuid4
+import string
 import urllib.request
 from urllib.error import HTTPError
 from pybtex.database import BibliographyData, Entry, parse_string, parse_file
@@ -79,7 +80,7 @@ class App:
         return:
             Error message: None | str
         """
-        key = str(uuid4())
+        key = self.generate_citekey(entry)
         entries = self._bib_data.entries
         title = entry.fields.get("title")
 
@@ -91,6 +92,39 @@ class App:
 
         self._bib_data.add_entry(key, entry)
         return None
+
+    def generate_citekey(self, entry: Entry) -> str:
+        """Generate an unique citekey for an entry
+
+        Args:
+            entry: the entry to generate a citekey for
+
+        Returns:
+            the generated citekey
+        """
+
+        # Get first author's last name
+        author = (
+            entry.persons.get("author")[0].last_names[0]
+            if entry.persons.get("author")
+            else "N/A"
+        )
+
+        # Get year
+        year = entry.fields.get("year", "N/A")
+
+        # Create citekey
+        citekey = f"{author}{year}"
+
+        # Check if citekey already exists and add a letter if it does
+        entries = self._bib_data.entries
+        if citekey in entries:
+            for char in string.ascii_lowercase:
+                new_citekey = f"{citekey}{char}"
+                if new_citekey not in entries:
+                    return new_citekey
+
+        return citekey
 
     def del_entries(self, entry_indices: list[int]):
         """Deletes select entries, or all.

--- a/src/tests/app_test.py
+++ b/src/tests/app_test.py
@@ -345,3 +345,31 @@ class TestApp(unittest.TestCase):
 
         # unsuccessful parsing returns tuple starting with False
         self.assertFalse(success)
+
+    def test_generate_citekey_generates_correct_citekey(self):
+        test_entry = TEST_ENTRY
+
+        # generated citekey should be correct
+        self.assertEqual(self.app.generate_citekey(test_entry), "Lastname1970")
+
+    def test_generate_citekey_generates_correct_citekey_with_duplicate(self):
+        # adding an general test entry
+        test_entry = TEST_ENTRY
+
+        self.app.add_entry(test_entry)
+
+        # adding a second entry with the same author and year but different title
+        second_entry = Entry(
+            "article",
+            persons={"author": [Person("Lastname, Firstname")]},
+            fields={
+                "title": "This is not the same title",
+                "journal": "Journal Name",
+                "year": "1970",
+                "volume": "1",
+                "pages": "10",
+            },
+        )
+
+        # generated citekey should be correct
+        self.assertEqual(self.app.generate_citekey(second_entry), "Lastname1970a")

--- a/src/tests/citekey.robot
+++ b/src/tests/citekey.robot
@@ -1,0 +1,32 @@
+*** Settings ***
+Library     ../AppLibrary.py
+Resource    resource.robot
+
+*** Test Cases ***
+Entry Will Get A Citekey Based On First Author And Year
+    Add Input    add
+    Input New Entry Details    Mikko Mäkinen and Susanna Lahti    Our first Article    Kanditutkielmat    2023    N/A    N/A    N/A
+    Add Input    list
+    Add Input    exit
+    Run Application
+    Skip Output
+    Skip Output
+    Skip Output
+    Output Should Contain    Mäkinen2023
+
+Entry With Same Author And Year Will Get A Citekey Based On First Author, Year And Letter
+    Add Input    add
+    Input New Entry Details    Mikko Mäkinen and Susanna Lahti    Our first Article    Kanditutkielmat    2023    N/A    N/A    N/A
+    Add Input    add
+    Input New Entry Details    Mikko Mäkinen and Susanna Lahti    Our second Article    Kanditutkielmat    2023    N/A    N/A    N/A
+    Add Input   list
+    Add Input    exit
+    Run Application
+    Skip Output
+    Skip Output
+    Skip Output
+    Skip Output
+    Skip Output
+    Output Should Contain    Mäkinen2023a
+
+

--- a/src/ui.py
+++ b/src/ui.py
@@ -307,9 +307,10 @@ def search_doi(io, app: App):
     search_result = app.get_bibtex_by_doi(doi)
     if search_result.startswith(" @"):
         entry = app.parse_entry_from_bibtex(search_result)
+        citekey = app.generate_citekey(entry)
         io.print(
             tabulate(
-                format_entries({doi: entry}, DEFAULT_FIELDS),
+                format_entries({citekey: entry}, DEFAULT_FIELDS),
                 headers="keys",
             ),
             "\n",

--- a/src/ui.py
+++ b/src/ui.py
@@ -310,7 +310,7 @@ def search_doi(io, app: App):
         success, entry = app.parse_entry_from_bibtex(search_result)
         if success:
             citekey = app.generate_citekey(entry)
-        io.print(
+            io.print(
                 tabulate(
                     format_entries({citekey: entry}, DEFAULT_FIELDS),
                     headers="keys",


### PR DESCRIPTION
Citekey generator.

Citekey format: {lastname of the first author + year in YYYY format + a-z if multiple articles with the same author and year},  for example Mäkinen2023 and if another article from Mikko Mäkinen from the year 2023 the another article gets citekey Mäkinen2023a and so on.

Applied when adding entry manually or using doi search. Does not change citekeys when .bib is loaded.